### PR TITLE
To fix ClassCastException

### DIFF
--- a/clojuresque-nrepl/src/main/groovy/clojuresque/tasks/ClojureRepl.groovy
+++ b/clojuresque-nrepl/src/main/groovy/clojuresque/tasks/ClojureRepl.groovy
@@ -125,7 +125,7 @@ class ClojureRepl extends DefaultTask {
     @TaskAction
     void startRepl() {
         def options = [
-            port:    port,
+            port:    "$port",
             handler: handler,
             middleware: middleware
         ]


### PR DESCRIPTION
[ Issue Description ]
1. Install clojuresque plugin correctly.
2. Run clojureRepl task directly.
Expected Result:
1. A new NREPL instance should run on port 7888.
Actual Result:
1. Throw ClassCastException at line 11 in clojuresque/tasks/repl.clj.

[ Solution ]
1. Modify ClojureRepl.groovy and transform port to String before calling API.
2. Modify repl.clj.
I choose the former.
